### PR TITLE
[feat] Deploy script for backer airdrop

### DIFF
--- a/packages/protocol/blockchain_scripts/airdrop/2022-01-24-backers/calculation.ts
+++ b/packages/protocol/blockchain_scripts/airdrop/2022-01-24-backers/calculation.ts
@@ -3,11 +3,7 @@ import {BigNumber as BigNum} from "bignumber.js"
 import {parseCsv} from "../community/parseCsv"
 import {program} from "commander"
 import {decimals} from "@goldfinch-eng/protocol/test/testHelpers"
-import {
-  LIQUIDITY_PROVIDER_GRANT_REASON,
-} from "@goldfinch-eng/protocol/blockchain_scripts/merkle/merkleDistributor/types"
-
-async function getNotVestedContracts() {}
+import {LIQUIDITY_PROVIDER_GRANT_REASON} from "@goldfinch-eng/protocol/blockchain_scripts/merkle/merkleDistributor/types"
 
 interface RawCSV {
   poolName: string
@@ -26,55 +22,74 @@ interface RawCSV {
 
 interface PreparedRow {
   backerAddress: string
-  immediatelyAvailable: BigNum,
+  immediatelyAvailable: BigNum
   vesting: BigNum
 }
 
 function sanitizeData(data: RawCSV[]): PreparedRow[] {
-  const toBigInt = (s: string) => new BigNum(s.replace(/,/g, ""))
-    .multipliedBy(decimals.toString())
+  const toBigInt = (s: string) => new BigNum(s.replace(/,/g, "")).multipliedBy(decimals.toString())
 
-  return data.map(row => ({
-      backerAddress: row['Backer Address'],
-      immediatelyAvailable: toBigInt(row['Immeditely available']),
-      vesting: toBigInt(row['Unlocks over 12 months']),
+  return data.map((row) => ({
+    backerAddress: row["Backer Address"],
+    immediatelyAvailable: toBigInt(row["Immeditely available"]),
+    vesting: toBigInt(row["Unlocks over 12 months"]),
   }))
 }
 
 async function saveImmediateData(data: PreparedRow[], path: string) {
   console.log(`Saving ${data.length} rows for no-vesting data to ${path}`)
-  await fs.writeFile(path, JSON.stringify(data.map(row => ({
-    account: row.backerAddress,
-    reason: LIQUIDITY_PROVIDER_GRANT_REASON,
-    grant: {
-      amount: row.immediatelyAvailable.toFixed(),
-      cliffLength: "0",
-      vestingInterval: "0",
-      vestingLength: "0",
-    }
-  })), null, 2))
+  await fs.writeFile(
+    path,
+    JSON.stringify(
+      data.map((row) => ({
+        account: row.backerAddress,
+        reason: LIQUIDITY_PROVIDER_GRANT_REASON,
+        grant: {
+          amount: row.immediatelyAvailable.toFixed(),
+          cliffLength: "0",
+          vestingInterval: "0",
+          vestingLength: "0",
+        },
+      })),
+      null,
+      2
+    )
+  )
 }
 
 async function saveVestingData(data: PreparedRow[], path: string) {
   console.log(`Saving ${data.length} rows for no-vesting data to ${path}`)
-  await fs.writeFile(path, JSON.stringify(data.map(row => ({
-    account: row.backerAddress,
-    reason: LIQUIDITY_PROVIDER_GRANT_REASON,
-    grant: {
-      amount: row.vesting.toFixed(),
-      cliffLength: "0",
-      vestingInterval: "2628000",  //  1 month
-      vestingLength:  "31536000",  // 12 months
-    }
-  })), null, 2))
+  await fs.writeFile(
+    path,
+    JSON.stringify(
+      data.map((row) => ({
+        account: row.backerAddress,
+        reason: LIQUIDITY_PROVIDER_GRANT_REASON,
+        grant: {
+          amount: row.vesting.toFixed(),
+          cliffLength: "0",
+          vestingInterval: "2628000", //  1 month
+          vestingLength: "31536000", // 12 months
+        },
+      })),
+      null,
+      2
+    )
+  )
 }
 
 async function main(inputFile: string, immediatelyAvailableFile: string, vestingFile: string) {
   const data = await parseCsv<RawCSV>(inputFile)
   const sanitizedData = sanitizeData(data)
   await Promise.all([
-    saveImmediateData(sanitizedData.filter(row => !row.immediatelyAvailable.isZero()), immediatelyAvailableFile),
-    saveVestingData(sanitizedData.filter(row => !row.vesting.isZero()), vestingFile)
+    saveImmediateData(
+      sanitizedData.filter((row) => !row.immediatelyAvailable.isZero()),
+      immediatelyAvailableFile
+    ),
+    saveVestingData(
+      sanitizedData.filter((row) => !row.vesting.isZero()),
+      vestingFile
+    ),
   ])
 }
 

--- a/packages/protocol/blockchain_scripts/baseDeploy/deployMerkleDirectDistributor.ts
+++ b/packages/protocol/blockchain_scripts/baseDeploy/deployMerkleDirectDistributor.ts
@@ -27,16 +27,16 @@ export async function deployMerkleDirectDistributor(
     gfi,
     deployEffects,
     merkleDirectDistributorInfoPath = process.env.MERKLE_DIRECT_DISTRIBUTOR_INFO_PATH,
+    contractName = "MerkleDirectDistributor",
   }: {
     gfi: Deployed<GFIInstance>
     deployEffects: DeployEffects
     merkleDirectDistributorInfoPath?: string
+    contractName?: string
   }
 ): Promise<Deployed<MerkleDirectDistributorInstance> | undefined> {
   const {gf_deployer} = await deployer.getNamedAccounts()
   const protocol_owner = await getProtocolOwner()
-
-  const contractName = "MerkleDirectDistributor"
 
   const merkleRoot = await getMerkleDirectDistributorRoot(merkleDirectDistributorInfoPath)
   if (!merkleRoot) {

--- a/packages/protocol/blockchain_scripts/baseDeploy/deployMerkleDistributor.ts
+++ b/packages/protocol/blockchain_scripts/baseDeploy/deployMerkleDistributor.ts
@@ -1,17 +1,10 @@
 import fs from "fs"
 import {toEthers} from "@goldfinch-eng/protocol/test/testHelpers"
-import {CommunityRewards, MerkleDistributor} from "@goldfinch-eng/protocol/typechain/ethers"
+import {CommunityRewards} from "@goldfinch-eng/protocol/typechain/ethers"
 import {CommunityRewardsInstance, MerkleDistributorInstance} from "@goldfinch-eng/protocol/typechain/truffle"
 import {assertIsString} from "@goldfinch-eng/utils"
 import {Deployed} from "../baseDeploy"
-import {
-  ContractDeployer,
-  DISTRIBUTOR_ROLE,
-  getContract,
-  getProtocolOwner,
-  getTruffleContract,
-  TRUFFLE_CONTRACT_PROVIDER,
-} from "../deployHelpers"
+import {ContractDeployer, DISTRIBUTOR_ROLE, getProtocolOwner, getTruffleContract} from "../deployHelpers"
 import {isMerkleDistributorInfo} from "../merkle/merkleDistributor/types"
 import {DeployEffects} from "../migrations/deployEffects"
 
@@ -57,14 +50,14 @@ export async function deployMerkleDistributor(
     communityRewards,
     deployEffects,
     merkleDistributorInfoPath = process.env.MERKLE_DISTRIBUTOR_INFO_PATH,
+    contractName = "MerkleDistributor",
   }: {
     communityRewards: Deployed<CommunityRewardsInstance>
     deployEffects: DeployEffects
     merkleDistributorInfoPath?: string
+    contractName?: string
   }
 ): Promise<Deployed<MerkleDistributorInstance> | undefined> {
-  const contractName = "MerkleDistributor"
-
   const merkleRoot = await getMerkleDistributorRoot(merkleDistributorInfoPath)
   if (!merkleRoot) {
     logger(`Merkle root is undefined. Skipping deploy of ${contractName}`)

--- a/packages/protocol/blockchain_scripts/migrations/v2.4/migrate.ts
+++ b/packages/protocol/blockchain_scripts/migrations/v2.4/migrate.ts
@@ -11,6 +11,7 @@ import {getDeployEffects} from "../deployEffects"
 import {isMerkleDistributorInfo} from "../../merkle/merkleDistributor/types"
 import {assertNonNullable} from "@goldfinch-eng/utils"
 import {isMerkleDirectDistributorInfo} from "../../merkle/merkleDirectDistributor/types"
+import {BigNumber} from "ethers"
 
 export const merkleDistributorInfoPath = path.join(
   __dirname,
@@ -20,6 +21,9 @@ export const merkleDirectDistributorInfoPath = path.join(
   __dirname,
   "../../merkle/merkleDirectDistributor/2022-01-24-backers-airdrop-merkleDirectDistributorInfo.json"
 )
+
+export const grantAddress1 = "0x379ED372c94CAe8B77dceb9987D7D6A04A31685D"
+export const grantAddress2 = "0xddbd3514F1cf38E1cdd332746B70c7325fbCcd04"
 
 export async function main() {
   const deployEffects = await getDeployEffects({
@@ -70,6 +74,10 @@ export async function main() {
   const communityRewardsEthersContract = await getEthersContract<CommunityRewards>("CommunityRewards")
   const gfiEthersContract = await getEthersContract<GFI>("GFI")
 
+  // A 550 GFI grant is specified as part of the governance proposal.
+  // This grant is to be split among the two developers who contributed to the backer airdrop calculation
+  const grantAmount = BigNumber.from(String(550e18)).div(2)
+
   deployEffects.add({
     deferred: [
       await gfiEthersContract.populateTransaction.approve(
@@ -85,6 +93,8 @@ export async function main() {
         merkleDirectDistributor.contract.address,
         merkleDirectDistributorAmount.toString()
       ),
+      await gfiEthersContract.populateTransaction.transfer(grantAddress1, grantAmount),
+      await gfiEthersContract.populateTransaction.transfer(grantAddress2, grantAmount),
     ],
   })
 

--- a/packages/protocol/blockchain_scripts/migrations/v2.4/migrate.ts
+++ b/packages/protocol/blockchain_scripts/migrations/v2.4/migrate.ts
@@ -1,0 +1,102 @@
+import {CommunityRewards, GFI} from "@goldfinch-eng/protocol/typechain/ethers"
+import {CommunityRewardsInstance} from "@goldfinch-eng/protocol/typechain/truffle"
+import {GFIInstance} from "@goldfinch-eng/protocol/typechain/truffle/GFI"
+import hre from "hardhat"
+import path from "path"
+import {promises as fs} from "fs"
+import {deployMerkleDirectDistributor} from "../../baseDeploy/deployMerkleDirectDistributor"
+import {deployMerkleDistributor} from "../../baseDeploy/deployMerkleDistributor"
+import {ContractDeployer, getEthersContract, getTruffleContract} from "../../deployHelpers"
+import {getDeployEffects} from "../deployEffects"
+import {isMerkleDistributorInfo} from "../../merkle/merkleDistributor/types"
+import {assertNonNullable} from "@goldfinch-eng/utils"
+import {isMerkleDirectDistributorInfo} from "../../merkle/merkleDirectDistributor/types"
+
+export const merkleDistributorInfoPath = path.join(
+  __dirname,
+  "../../merkle/merkleDistributor/2022-01-24-backers-airdrop-merkleDistributorInfo.json"
+)
+export const merkleDirectDistributorInfoPath = path.join(
+  __dirname,
+  "../../merkle/merkleDirectDistributor/2022-01-24-backers-airdrop-merkleDirectDistributorInfo.json"
+)
+
+export async function main() {
+  const deployEffects = await getDeployEffects({
+    title: "Backer airdrop",
+    description: "https://gov.goldfinch.finance/t/retroactive-backer-distribution-proposal-3-with-data/252",
+  })
+
+  const deployer = new ContractDeployer(console.log, hre)
+
+  console.log("Starting deployment")
+
+  const communityRewardsContract = await getTruffleContract<CommunityRewardsInstance>("CommunityRewards")
+  const communityRewards = {name: "CommunityRewards", contract: communityRewardsContract}
+  const gfiContract = await getTruffleContract<GFIInstance>("GFI")
+  const gfi = {name: "GFI", contract: gfiContract}
+
+  console.log("Deploying merkle distributors")
+
+  const merkleDistributorInfo = JSON.parse(String(await fs.readFile(merkleDistributorInfoPath)))
+  if (!isMerkleDistributorInfo(merkleDistributorInfo)) {
+    throw new Error("Invalid merkle distributor info")
+  }
+  const merkleDirectDistributorInfo = JSON.parse(String(await fs.readFile(merkleDirectDistributorInfoPath)))
+  if (!isMerkleDirectDistributorInfo(merkleDirectDistributorInfo)) {
+    throw new Error("Invalid merkle direct distributor info")
+  }
+
+  const merkleDistributor = await deployMerkleDistributor(deployer, {
+    contractName: "BackerMerkleDistributor",
+    communityRewards,
+    deployEffects,
+    merkleDistributorInfoPath,
+  })
+  assertNonNullable(merkleDistributor, "BackerMerkleDistributor is null")
+  const merkleDirectDistributor = await deployMerkleDirectDistributor(deployer, {
+    contractName: "BackerMerkleDirectDistributor",
+    gfi,
+    deployEffects,
+    merkleDirectDistributorInfoPath,
+  })
+  assertNonNullable(merkleDirectDistributor, "BackerMerkleDirectDistributor is null")
+
+  console.log("Loading rewards")
+
+  const merkleDistributorAmount = web3.utils.toBN(merkleDistributorInfo.amountTotal)
+  const merkleDirectDistributorAmount = web3.utils.toBN(merkleDirectDistributorInfo.amountTotal)
+
+  const communityRewardsEthersContract = await getEthersContract<CommunityRewards>("CommunityRewards")
+  const gfiEthersContract = await getEthersContract<GFI>("GFI")
+
+  deployEffects.add({
+    deferred: [
+      await gfiEthersContract.populateTransaction.approve(
+        communityRewardsEthersContract.address,
+        merkleDistributorAmount.toString()
+      ),
+      await communityRewardsEthersContract.populateTransaction.loadRewards(merkleDistributorAmount.toString()),
+      await gfiEthersContract.populateTransaction.approve(
+        merkleDirectDistributor.contract.address,
+        merkleDirectDistributorAmount.toString()
+      ),
+      await gfiEthersContract.populateTransaction.transfer(
+        merkleDirectDistributor.contract.address,
+        merkleDirectDistributorAmount.toString()
+      ),
+    ],
+  })
+
+  await deployEffects.executeDeferred()
+  return {}
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
+}

--- a/packages/protocol/contracts/rewards/BackerMerkleDirectDistributor.sol
+++ b/packages/protocol/contracts/rewards/BackerMerkleDirectDistributor.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.6.12;
+
+import "./MerkleDirectDistributor.sol";
+
+// solhint-disable-next-line no-empty-blocks
+contract BackerMerkleDirectDistributor is MerkleDirectDistributor {
+
+}

--- a/packages/protocol/contracts/rewards/BackerMerkleDistributor.sol
+++ b/packages/protocol/contracts/rewards/BackerMerkleDistributor.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.6.12;
+
+import "./MerkleDistributor.sol";
+
+contract BackerMerkleDistributor is MerkleDistributor {
+  constructor(address communityRewards_, bytes32 merkleRoot_)
+    public
+    MerkleDistributor(communityRewards_, merkleRoot_)
+  // solhint-disable-next-line no-empty-blocks
+  {
+
+  }
+}

--- a/packages/protocol/test/mainnet_forking/blockchain_scripts/migrations/v2.4/migrate.test.ts
+++ b/packages/protocol/test/mainnet_forking/blockchain_scripts/migrations/v2.4/migrate.test.ts
@@ -1,0 +1,119 @@
+import {promises as fs} from "fs"
+import hre, {deployments, getNamedAccounts} from "hardhat"
+import {assertIsString} from "packages/utils/src/type"
+import {
+  DISTRIBUTOR_ROLE,
+  getProtocolOwner,
+  getTruffleContract,
+  ZERO_ADDRESS,
+} from "packages/protocol/blockchain_scripts/deployHelpers"
+import {fundWithWhales} from "@goldfinch-eng/protocol/blockchain_scripts/helpers/fundWithWhales"
+
+import * as migrate2_4 from "@goldfinch-eng/protocol/blockchain_scripts/migrations/v2.4/migrate"
+import {expectOwnerRole, expectProxyOwner, expectRoles} from "@goldfinch-eng/protocol/test/testHelpers"
+import {TEST_TIMEOUT} from "../../../MainnetForking.test"
+import {impersonateAccount} from "@goldfinch-eng/protocol/blockchain_scripts/helpers/impersonateAccount"
+import {isMerkleDistributorInfo} from "@goldfinch-eng/protocol/blockchain_scripts/merkle/merkleDistributor/types"
+import {isMerkleDirectDistributorInfo} from "@goldfinch-eng/protocol/blockchain_scripts/merkle/merkleDirectDistributor/types"
+import BN from "bn.js"
+import {
+  BackerMerkleDirectDistributorInstance,
+  CommunityRewardsInstance,
+  GFIInstance,
+} from "@goldfinch-eng/protocol/typechain/truffle"
+
+const setupTest = deployments.createFixture(async () => {
+  await deployments.fixture("base_deploy", {keepExistingDeployments: true})
+
+  const gfi = await getTruffleContract<GFIInstance>("GFI")
+  const communityRewards = await getTruffleContract<CommunityRewardsInstance>("CommunityRewards")
+  const communityRewardsStartingBalance = await communityRewards.rewardsAvailable()
+
+  const {gf_deployer} = await getNamedAccounts()
+  assertIsString(gf_deployer)
+  await fundWithWhales(["ETH"], [gf_deployer])
+  await impersonateAccount(hre, await getProtocolOwner())
+  await fundWithWhales(["ETH"], [await getProtocolOwner()])
+
+  await migrate2_4.main()
+
+  return {
+    gfi,
+    communityRewards,
+    communityRewardsStartingBalance,
+  }
+})
+
+describe("v2.4", async function () {
+  this.timeout(TEST_TIMEOUT)
+
+  let gfi: GFIInstance
+  let communityRewards: CommunityRewardsInstance
+  let communityRewardsStartingBalance: BN
+
+  beforeEach(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({gfi, communityRewards, communityRewardsStartingBalance} = await setupTest())
+    console.log("communityRewardsStartingBalance", communityRewardsStartingBalance.toString())
+  })
+
+  it("deploys BackerMerkleDirectDistributor", async () => {
+    await expect(deployments.get("BackerMerkleDirectDistributor")).to.not.be.rejected
+  })
+
+  it("initializes BackerMerkleDirectDistributor", async () => {
+    await expect(
+      (
+        await getTruffleContract<BackerMerkleDirectDistributorInstance>("BackerMerkleDirectDistributor")
+      ).initialize(ZERO_ADDRESS, ZERO_ADDRESS, web3.utils.keccak256("test"), {from: await getProtocolOwner()})
+    ).to.be.rejectedWith(/initialized/)
+  })
+
+  it("deploys BackerMerkleDistributor", async () => {
+    await expect(deployments.get("BackerMerkleDistributor")).to.not.be.rejected
+  })
+
+  expectProxyOwner({
+    toBe: async () => getProtocolOwner(),
+    forContracts: ["BackerMerkleDirectDistributor"],
+  })
+
+  expectOwnerRole({
+    toBe: async () => getProtocolOwner(),
+    forContracts: ["BackerMerkleDirectDistributor"],
+  })
+
+  expectRoles([
+    {
+      contractName: "CommunityRewards",
+      roles: [DISTRIBUTOR_ROLE],
+      address: async () => (await deployments.get("BackerMerkleDistributor")).address,
+    },
+  ])
+
+  it("loads GFI into CommunityRewards using merkleDistributorInfo amount", async () => {
+    const merkleDistributorInfo = JSON.parse(String(await fs.readFile(migrate2_4.merkleDistributorInfoPath)))
+    if (!isMerkleDistributorInfo(merkleDistributorInfo)) {
+      throw new Error("Invalid merkle distributor info")
+    }
+    const merkleDistributorAmount = web3.utils.toBN(merkleDistributorInfo.amountTotal)
+
+    const rewardsAvailable = await communityRewards.rewardsAvailable()
+
+    expect(rewardsAvailable.sub(communityRewardsStartingBalance)).to.bignumber.eq(merkleDistributorAmount)
+  })
+
+  it("loads GFI into BackerMerkleDirectDistributor using merkleDirectDistributorInfo amount", async () => {
+    const merkleDirectDistributorInfo = JSON.parse(
+      String(await fs.readFile(migrate2_4.merkleDirectDistributorInfoPath))
+    )
+    if (!isMerkleDirectDistributorInfo(merkleDirectDistributorInfo)) {
+      throw new Error("Invalid merkle direct distributor info")
+    }
+    const merkleDirectDistributorAmount = web3.utils.toBN(merkleDirectDistributorInfo.amountTotal)
+
+    const directDistributor = await deployments.get("BackerMerkleDirectDistributor")
+
+    expect(await gfi.balanceOf(directDistributor.address)).to.bignumber.eq(merkleDirectDistributorAmount)
+  })
+})


### PR DESCRIPTION
### What happened?
* Add deploy script to deploy merkle distributors for backer airdrop (using merkle roots generated in https://github.com/goldfinch-eng/mono/pull/8)
* Fix lint errors

### Why?
* https://gov.goldfinch.finance/t/retroactive-backer-distribution-proposal-3-with-data/252

### How has this been tested?
* New mainnet-forking tests

**Checklist**
- [x] I have reviewed this code myself
- [ ] Screenshots of the key change are present (if this is a front-end PR)
